### PR TITLE
More source for auth data

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -154,9 +154,13 @@ Here's the argument(s), their accepted source, and corresponding keys.
 
 ##### `token`
 
-| key   | config file | env var        | keyring        |
-|-------|:------------|:---------------|:---------------|
-| token | ⛔️          | `VAULT_TOKEN`  | `token/:token` |
+| key   | config file | env var        | keyring        | helper |
+|-------|:------------|:---------------|:---------------|--------|
+| token | ⛔️          | `VAULT_TOKEN`  | `token/:token` | ✅     |
+
+*[Token helper](https://www.vaultproject.io/docs/commands/token-helper)*: Vault CLI stores the generated token in the `~/.vault-token` file after authenticated. This app reads the token from that file, but it do not create one on authenticating using this app.
+
+To use the helper, you can use command [`vault login`](https://www.vaultproject.io/docs/commands/login) to create one.
 
 ##### `okta`
 

--- a/Readme.md
+++ b/Readme.md
@@ -18,13 +18,13 @@ This tool is built to *plug in* secrets into development without landing data on
 > Standard CLI usage is not implemented yet.
 > Currently this app could only be used as a poetry plugin. Plugin is a poetry **1.2.0** feature, which is still in beta testing.
 
-Get it from this repository:
+Get it from [PyPI](https://pypi.org/project/secrets.env/):
 
 ```bash
 # add as poetry global plugin
 poetry self add secrets.env -E yaml
 
-# add to project's virtual environment
+# add to local project
 poetry add --group=dev secrets.env -E toml
 ```
 
@@ -41,7 +41,7 @@ You can use this package as a [poetry plugin](https://python-poetry.org/docs/mas
 
 ```bash
 # 1. install plugin
-poetry self add secrets.env -E yaml
+poetry add --group=dev secrets.env -E yaml
 
 # 2. setup config
 #    read configuration section below for details
@@ -134,25 +134,30 @@ source:
 
 *Arguments*
 
-Auth data could be provided by various source: config file, environment variable, system keyring service... etc.
+Auth data could be provided by various source, including:
 
-We're using [keyring] package, which reads and saves the values from system keyring, e.g. OSX [Keychain] or KDE [KWallet]. For reading/saving value into keyring, use its [command line utility] with the system name `secrets.env`:
+* **Config file:** Place the config value under `auth` section, use the key provided in the table.
+* **Environment variable:** In most cases, environment variable could be used to overwrite the values from config file.
+* **Keyring:** We're using [keyring] package to read the values from system keyring (e.g. OSX [Keychain]). For saving a value into keyring, use its [command line utility] with the system name `secrets.env`:
 
-[keyring]: https://keyring.readthedocs.io/en/latest/
-[Keychain]: https://en.wikipedia.org/wiki/Keychain_%28software%29
-[KWallet]: https://en.wikipedia.org/wiki/KWallet
-[command line utility]: https://keyring.readthedocs.io/en/latest/#command-line-utility
+  ```bash
+  keyring get secrets.env token/:token
+  keyring set secrets.env okta/test@example.com
+  ```
 
-```bash
-keyring get secrets.env token/:token
-keyring set secrets.env okta/test@example.com
-```
+  [keyring]: https://keyring.readthedocs.io/en/latest/
+  [Keychain]: https://en.wikipedia.org/wiki/Keychain_%28software%29
+  [command line utility]: https://keyring.readthedocs.io/en/latest/#command-line-utility
+
+* **Prompt:** If no data found in all other sources, it prompts user for input. Prompt is only enabled when optional dependency [click](https://click.palletsprojects.com/en/8.1.x/) is installed, and you can disable it by setting environment variable `SECRETS_ENV_NO_PROMPT=True`.
+
+<!-- for credentials can be displayed. -->
 
 #### Supported methods
 
 Here's the argument(s), their accepted source, and corresponding keys.
 
-##### `token`
+##### method: `token`
 
 | key   | config file | env var        | keyring        | helper |
 |-------|:------------|:---------------|:---------------|--------|
@@ -162,9 +167,9 @@ Here's the argument(s), their accepted source, and corresponding keys.
 
 To use the helper, you can use command [`vault login`](https://www.vaultproject.io/docs/commands/login) to create one.
 
-##### `okta`
+##### method: `okta`
 
-| key      | config file | env var          | keyring               |
-|----------|:------------|:-----------------|:----------------------|
-| username | `username`  | `VAULT_USERNAME` | `okta/:username`      |
-| password | ⛔️          | `VAULT_PASSWORD` | `okta/YOUR_USER_NAME` |
+| key      | config file | environment variable   | keyring               | prompt |
+|----------|:------------|:-----------------------|:----------------------|--------|
+| username | `username`  | `SECRETS_ENV_USERNAME` | `okta/:username`      | ✅     |
+| password | ⛔️          | `SECRETS_ENV_PASSWORD` | `okta/YOUR_USER_NAME` | ✅     |

--- a/poetry.lock
+++ b/poetry.lock
@@ -119,7 +119,7 @@ pylev = ">=1.3.0,<2.0.0"
 name = "click"
 version = "8.1.3"
 description = "Composable command line interface toolkit"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -131,7 +131,7 @@ importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 name = "colorama"
 version = "0.4.5"
 description = "Cross-platform colored terminal text."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -788,7 +788,7 @@ yaml = ["PyYAML"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "41b694e655db36d584ad4cd69f515c3a1a87d1ec39eb349bbd6c5d2eb8e5b5df"
+content-hash = "3e94a16f68f90d2a6ac411c3627769cfc1572ae9c4ba665710ed4990280066a9"
 
 [metadata.files]
 atomicwrites = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ requests = "^2.28.1"
 keyring = "^23.6.0"
 tomli = {version = "^2.0.1", python = "<3.11", optional = true}
 PyYAML = {version = "^6.0", optional = true}
+click = {version = "^8.1.3", optional = true}
 
 [tool.poetry.dev-dependencies]
 flake8 = "^4.0.1"

--- a/secrets_env/auth.py
+++ b/secrets_env/auth.py
@@ -25,8 +25,9 @@ def get_password(name: str) -> Optional[str]:
 class Auth(abc.ABC):
     """Base class for authentication schemes."""
 
-    method: str
-    """Authentication method."""
+    @abc.abstractclassmethod
+    def method(cls) -> str:
+        """Returns authentication name."""
 
     @abc.abstractmethod
     def apply(self, client: "hvac.Client") -> None:
@@ -54,8 +55,11 @@ class TokenAuth(Auth):
         """
         if not isinstance(token, str):
             raise TypeError("Expect str for token, got {}", type(token).__name__)
-        object.__setattr__(self, "method", "token")
         object.__setattr__(self, "token", token)
+
+    @classmethod
+    def method(cls) -> str:
+        return "token"
 
     def apply(self, client: "hvac.Client"):
         client.token = self.token
@@ -97,9 +101,12 @@ class OktaAuth(Auth):
             raise TypeError("Expect str for username, got {}", type(username).__name__)
         if not isinstance(password, str):
             raise TypeError("Expect str for password, got {}", type(password).__name__)
-        object.__setattr__(self, "method", "okta")
         object.__setattr__(self, "username", username)
         object.__setattr__(self, "password", password)
+
+    @classmethod
+    def method(cls):
+        return "okta"
 
     def apply(self, client: "hvac.Client"):
         logger.info(

--- a/secrets_env/auth.py
+++ b/secrets_env/auth.py
@@ -1,15 +1,18 @@
 import abc
+import importlib
 import logging
 import os
 import pathlib
+import sys
 import typing
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 import keyring
 import keyring.errors
 
 if typing.TYPE_CHECKING:
+    import click
     import hvac
 
 
@@ -17,9 +20,59 @@ logger = logging.getLogger(__name__)
 
 
 def get_password(name: str) -> Optional[str]:
+    """Wrapped `keyring.get_password`. Do not raise error when there is no
+    keyring backend enabled."""
     try:
         return keyring.get_password("secrets.env", name)
     except keyring.errors.NoKeyringError:
+        return None
+
+
+def prompt(
+    text: str,
+    default: Optional[Any] = None,
+    hide_input: bool = False,
+    type: Optional[Union["click.types.ParamType", Any]] = None,
+    show_default: bool = True,
+) -> Optional[Any]:
+    """Wrapped `click.prompt` function. Only shows the prompt when click is
+    installed and this feature is not disabled.
+
+    Parameters
+    ----------
+    text : str
+        The text to show for the prompt.
+    default : Optional[Any]
+        The default value to use if no input happens. If this is not given it
+        will prompt until it's aborted.
+    hide_input : bool
+        If this is set to true then the input value will be hidden.
+    type : Optional[Union[click.types.ParamType, Any]]
+        The type to use to check the value against.
+    show_default : bool
+        Shows or hides the default value in the prompt.
+    """
+    # skip prompt if click is not installed
+    try:
+        click = importlib.import_module("click")
+    except ImportError:
+        return None
+
+    # skip prompt if the env var is set
+    env = os.getenv("SECRETS_ENV_NO_PROMPT", "FALSE")
+    if env.upper() in ("TRUE", "T", "YES", "Y", "1"):
+        return None
+
+    try:
+        return click.prompt(
+            text=text,
+            default=default,
+            hide_input=hide_input,
+            type=type,
+            show_default=show_default,
+        )
+    except click.Abort:
+        sys.stdout.write(os.linesep)
         return None
 
 
@@ -120,20 +173,24 @@ class UserPasswordAuth(Auth):
             username = data.get("username")
         if not username:
             username = get_password(f"{method}/:username")
+        if not username:
+            username = prompt(f"Username for {method} auth")
         if not isinstance(username, str):
             logger.error(
-                "Missing auth information: username. Neither key 'username' in "
-                "config nor environment variable `VAULT_USERNAME` is found."
+                "Missing username for %s auth. Stop loading secrets.",
+                method,
             )
             return None
 
         password = os.getenv("VAULT_PASSWORD")
         if not password:
             password = get_password(f"{method}/{username}")
+        if not password:
+            password = prompt("Password", hide_input=True)
         if not isinstance(password, str):
             logger.error(
-                "Missing auth information: password. "
-                "Environment variable `VAULT_PASSWORD` not found."
+                "Missing password for %s auth. Stop loading secrets.",
+                method,
             )
             return None
 

--- a/secrets_env/auth.py
+++ b/secrets_env/auth.py
@@ -1,6 +1,7 @@
 import abc
 import logging
 import os
+import pathlib
 import typing
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
@@ -67,6 +68,12 @@ class TokenAuth(Auth):
     @classmethod
     def load(cls, data: Dict[str, Any]) -> Optional["Auth"]:
         token = os.getenv("VAULT_TOKEN")
+        if not token:
+            # vault places the token on the disk
+            # https://www.vaultproject.io/docs/commands/token-helper
+            file_ = pathlib.Path.home() / ".vault-token"
+            if file_.is_fifo():
+                token = file_.read_text().strip()
         if not token:
             token = get_password("token/:token")
         if not isinstance(token, str):

--- a/secrets_env/auth.py
+++ b/secrets_env/auth.py
@@ -168,7 +168,7 @@ class UserPasswordAuth(Auth):
     def load(cls, data: Dict[str, Any]) -> Optional["Auth"]:
         method = cls.method()
 
-        username = os.getenv("VAULT_USERNAME")
+        username = os.getenv("SECRETS_ENV_USERNAME")
         if not username:
             username = data.get("username")
         if not username:
@@ -182,7 +182,7 @@ class UserPasswordAuth(Auth):
             )
             return None
 
-        password = os.getenv("VAULT_PASSWORD")
+        password = os.getenv("SECRETS_ENV_PASSWORD")
         if not password:
             password = get_password(f"{method}/{username}")
         if not password:

--- a/secrets_env/reader.py
+++ b/secrets_env/reader.py
@@ -46,7 +46,7 @@ class KVReader:
         logger.debug(
             "Vault client initialization requested. URL= %s, Auth type= %s",
             self.url,
-            self.auth.method,
+            self.auth.method(),
         )
 
         client = hvac.Client(self.url)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -110,7 +110,10 @@ class TestUserPasswordAuth:
         # overwrite username
         with patch.dict(
             "os.environ",
-            {"VAULT_USERNAME": "user-2@example.com", "VAULT_PASSWORD": "P@ssw0rd"},
+            {
+                "SECRETS_ENV_USERNAME": "user-2@example.com",
+                "SECRETS_ENV_PASSWORD": "P@ssw0rd",
+            },
         ):
             obj = auth.UserPasswordAuth.load({"username": "user-1@example.com"})
         assert obj == auth.UserPasswordAuth("user-2@example.com", "P@ssw0rd")
@@ -118,7 +121,7 @@ class TestUserPasswordAuth:
         # password only
         with patch.dict(
             "os.environ",
-            {"VAULT_PASSWORD": "P@ssw0rd"},
+            {"SECRETS_ENV_PASSWORD": "P@ssw0rd"},
         ):
             obj = auth.UserPasswordAuth.load({"username": "user-1@example.com"})
         assert obj == auth.UserPasswordAuth("user-1@example.com", "P@ssw0rd")
@@ -145,7 +148,7 @@ class TestUserPasswordAuth:
 
     @pytest.mark.usefixtures("_unfreeze")
     def test_load_mixed(self):
-        with patch.dict("os.environ", {"VAULT_PASSWORD": "P@ssw0rd"}), patch(
+        with patch.dict("os.environ", {"SECRETS_ENV_PASSWORD": "P@ssw0rd"}), patch(
             "secrets_env.auth.get_password", return_value="user-2@example.com"
         ):
             obj = auth.UserPasswordAuth.load({})

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,70 +1,153 @@
+import logging
 from unittest.mock import Mock, patch
 
 import hvac
+import keyring.errors
 import pytest
 
 from secrets_env import auth
 
 
-class TestAuth:
-    @pytest.fixture()
-    def get_password(self):
-        with patch("secrets_env.auth.get_password", return_value=None) as kr:
-            yield kr
+def test_get_password():
+    with patch("keyring.get_password", return_value="bar"):
+        assert auth.get_password("foo") == "bar"
+    with patch("keyring.get_password", side_effect=keyring.errors.NoKeyringError()):
+        assert auth.get_password("foo") is None
 
+
+class TestTokenAuth:
     def setup_method(self):
-        self.client = Mock(spec=hvac.Client)
+        self.obj = auth.TokenAuth("T0ken")
 
-    def test_token_auth(self, get_password: Mock):
-        # success
-        obj = auth.TokenAuth("Token")
-        assert obj.method() == "token"
-        assert obj.token == "Token"
+    def test__init__(self):
+        assert self.obj.method() == "token"
+        assert self.obj.token == "T0ken"
 
-        # fail
         with pytest.raises(TypeError):
             auth.TokenAuth(1234)
 
-        # apply
-        obj.apply(self.client)
-        assert self.client.token == "Token"
+    def test__repr__(self):
+        assert repr(self.obj) == "TokenAuth(token='T0ken')"
 
-        # create
-        assert auth.TokenAuth.load({}) is None
+    def test_method(self):
+        assert auth.TokenAuth.method() == "token"
 
+    def test_apply(self):
+        # set up token doesn't trigger connection, so uses real client
+        client = hvac.Client("https://example.com")
+        self.obj.apply(client)
+        assert client.token == "T0ken"
+
+    def test_load(self):
+        # success
         with patch.dict("os.environ", {"VAULT_TOKEN": "foo"}):
             assert auth.TokenAuth.load({}) == auth.TokenAuth("foo")
 
-        get_password.return_value = "Token"
-        assert auth.TokenAuth.load({}) == auth.TokenAuth("Token")
+        with patch("secrets_env.auth.get_password", return_value="foo"):
+            assert auth.TokenAuth.load({}) == auth.TokenAuth("foo")
 
-    def test_okta_auth(self, get_password: Mock):
+        # no data
+        assert auth.TokenAuth.load({}) is None
+
+
+class TestUserPasswordAuth:
+    @pytest.fixture()
+    def _unfreeze(self):
+        """UserPasswordAuth has some required abstract method not implemented.
+        Use this fixture to patch the propertires for running the test."""
+        with patch.object(auth.UserPasswordAuth, "__abstractmethods__", set()), patch(
+            "secrets_env.auth.UserPasswordAuth.method", return_value="mock"
+        ):
+            yield
+
+    @pytest.mark.usefixtures("_unfreeze")
+    def test___init__(self):
         # success
-        obj = auth.OktaAuth("User", "P@ssw0rd")
-        assert obj.method() == "okta"
-        assert obj.username == "User"
+        obj = auth.UserPasswordAuth("user@example.com", "P@ssw0rd")
+        assert obj.username == "user@example.com"
         assert obj.password == "P@ssw0rd"
 
-        # fail
+        # error
         with pytest.raises(TypeError):
-            auth.OktaAuth(1234, "P@ssw0rd")
+            auth.UserPasswordAuth(1234, "P@ssw0rd")
         with pytest.raises(TypeError):
-            auth.OktaAuth("User", 1234)
+            auth.UserPasswordAuth("user@example.com", 1234)
 
-        # apply
-        obj.apply(self.client)
-        assert self.client.auth.okta.login.call_count == 1
-
-        # create
+    @pytest.mark.usefixtures("_unfreeze")
+    def test_load_from_env(self):
+        # overwrite username
         with patch.dict(
-            "os.environ", {"VAULT_USERNAME": "foo", "VAULT_PASSWORD": "bar"}
+            "os.environ",
+            {"VAULT_USERNAME": "user-2@example.com", "VAULT_PASSWORD": "P@ssw0rd"},
         ):
-            assert auth.OktaAuth.load({}) == auth.OktaAuth("foo", "bar")
+            obj = auth.UserPasswordAuth.load({"username": "user-1@example.com"})
+        assert obj == auth.UserPasswordAuth("user-2@example.com", "P@ssw0rd")
 
-        with patch.dict("os.environ", {"VAULT_USERNAME": "foo"}):
-            assert auth.OktaAuth.load({}) is None
-        with patch.dict("os.environ", {"VAULT_PASSWORD": "bar"}):
-            assert auth.OktaAuth.load({}) is None
+        # password only
+        with patch.dict(
+            "os.environ",
+            {"VAULT_PASSWORD": "P@ssw0rd"},
+        ):
+            obj = auth.UserPasswordAuth.load({"username": "user-1@example.com"})
+        assert obj == auth.UserPasswordAuth("user-1@example.com", "P@ssw0rd")
 
-        get_password.side_effect = ["test@example.com", "P@ssw0rd"]
-        assert auth.OktaAuth.load({}) == auth.OktaAuth("test@example.com", "P@ssw0rd")
+    @pytest.mark.usefixtures("_unfreeze")
+    def test_load_from_keyring(self):
+        # username + password
+        with patch(
+            "secrets_env.auth.get_password",
+            side_effect=["user-2@example.com", "P@ssw0rd"],
+        ) as g:
+            obj = auth.UserPasswordAuth.load({})
+
+        assert obj == auth.UserPasswordAuth("user-2@example.com", "P@ssw0rd")
+        g.assert_any_call("mock/:username")
+        g.assert_any_call("mock/user-2@example.com")
+
+        # from keyring, password only
+        with patch("secrets_env.auth.get_password", return_value="P@ssw0rd") as g:
+            obj = auth.UserPasswordAuth.load({"username": "user-1@example.com"})
+
+        assert obj == auth.UserPasswordAuth("user-1@example.com", "P@ssw0rd")
+        g.assert_any_call("mock/user-1@example.com")
+
+    @pytest.mark.usefixtures("_unfreeze")
+    def test_load_mixed(self):
+        with patch.dict("os.environ", {"VAULT_PASSWORD": "P@ssw0rd"}), patch(
+            "secrets_env.auth.get_password", return_value="user-2@example.com"
+        ):
+            obj = auth.UserPasswordAuth.load({})
+
+        assert obj == auth.UserPasswordAuth("user-2@example.com", "P@ssw0rd")
+
+    @pytest.mark.usefixtures("_unfreeze")
+    def test_load_missing(self, caplog: pytest.LogCaptureFixture):
+        with caplog.at_level(logging.ERROR):
+            assert auth.UserPasswordAuth.load({}) is None
+            assert "Missing auth information: username." in caplog.text
+
+        with caplog.at_level(logging.ERROR):
+            obj = auth.UserPasswordAuth.load({"username": "user-1@example.com"})
+            assert obj is None
+            assert "Missing auth information: password" in caplog.text
+
+
+class TestOktaAuth:
+    def setup_method(self):
+        self.obj = auth.OktaAuth("user", "pass")
+
+    def test__init__(self):
+        assert self.obj.username == "user"
+        assert self.obj.password == "pass"
+
+    def test__repr__(self):
+        assert repr(self.obj) == "OktaAuth(username='user')"
+
+    def test_method(self):
+        assert auth.OktaAuth.method() == "okta"
+
+    def test_apply(self):
+        client = Mock(spec=hvac.Client)
+
+        self.obj.apply(client)
+        assert client.auth.okta.login.call_count == 1

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -131,7 +131,7 @@ class TestReader:
 class TestReaderGetEngineAndVersion:
     def setup_method(self):
         auth = Mock(spec=secrets_env.auth.Auth)
-        auth.method = "mocked"
+        auth.method.return_value = "mocked"
 
         self.reader = reader.KVReader("https://example.com", auth)
 
@@ -197,7 +197,7 @@ class TestReaderGetEngineAndVersion:
 class TestReaderGetSecret:
     def setup_method(self):
         auth = Mock(spec=secrets_env.auth.Auth)
-        auth.method = "mocked"
+        auth.method.return_value = "mocked"
 
         self.reader = reader.KVReader("https://example.com", auth)
 


### PR DESCRIPTION
- catch keyring error
- set method as a member function
- split username auth
- refactor test
- add: read token from disk
- add test for _load_from_home
- add click
- add prompt
- revise readme & reset prefix
- patch prompt
- add test for prompt
