### PR TITLE
enh: use the provider type name as default instance name

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,11 +4,40 @@ Changelog
 Unreleased
 ==========
 
-Changed
-+++++++
+Enhancements
+++++++++++++
 
 * Prevent saving Vault token to token helper for root user.
+
+* Use the provider type name as default instance name.
+
+  This simplifies the configuration file when only one instance is defined:
+
+  .. code-block:: yaml
+
+     sources:
+       # This source will be named as `plain`
+       - type: plain
+
+     secrets:
+       - name: DEMO
+         source: plain
+         value: Hello, world!
+
 * Set the provider as default when only one is installed.
+
+  This simplifies the configuration file when only one provider is installed:
+
+  .. code-block:: yaml
+
+     sources:
+       - name: ExampleSource
+         type: plain
+
+     secrets:
+       # This secret will be fetched from `ExampleSource`
+       - name: DEMO
+         value: Hello, world!
 
 Docs
 ++++

--- a/docs/configurations.rst
+++ b/docs/configurations.rst
@@ -160,14 +160,16 @@ The supported provider types includes:
 
   This creates a :doc:`provider/vault`, capable of retrieving secrets from `HashiCorp Vault <https://www.vaultproject.io/>`_.
 
+When the ``name`` field is omitted, the provider will be assigned a default name based on the provider type.
+For example, a provider of type ``vault`` will be assigned the name ``vault``.
+
 
 Single source
 ^^^^^^^^^^^^^
 
 When there's only one source in the configuration, several things can be omitted:
 
-* Field ``name`` can be excluded from source section.
-* Field ``source`` can be omitted from the secrets section.
+* Field ``source`` can be omitted from the secrets section, the source will be used by default.
 * The source metadata can be set directly under the source(s) key (rather than under a list).
 
 .. tab-set::

--- a/secrets_env/config/parser.py
+++ b/secrets_env/config/parser.py
@@ -46,8 +46,7 @@ class _ProviderBuilder(BaseModel):
                 )
             return providers
 
-        else:
-            raise ValueError("Input must be a list or a dictionary")
+        raise ValueError("Input must be a list or a dictionary")
 
     def to_dict(self) -> dict[str, Provider]:
         """
@@ -67,23 +66,12 @@ class _ProviderBuilder(BaseModel):
                     {
                         "type": "value_error",
                         "loc": ("sources", "*", "name"),
-                        "input": provider.name or "(anonymous)",
+                        "input": provider.name,
                         "ctx": {"error": "duplicated source name"},
                     }
                 )
             else:
                 providers[provider.name] = provider
-
-        if None in providers and len(providers) > 1:
-            errors.append(
-                {
-                    "type": "value_error",
-                    "loc": ("sources", "*", "name"),
-                    "ctx": {
-                        "error": "naming each source is mandatory when using multiple sources",
-                    },
-                }
-            )
 
         if errors:
             raise ValidationError.from_exception_data(
@@ -118,7 +106,7 @@ class _RequestBuilder(BaseModel):
         if isinstance(value, list):
             return value
 
-        elif isinstance(value, dict):
+        if isinstance(value, dict):
             requests = []
             errors = []
             for name, spec in value.items():
@@ -138,9 +126,8 @@ class _RequestBuilder(BaseModel):
                 )
             return requests
 
-        else:
-            # type error here does not get caught by pydantic
-            raise ValueError(f'expect list or dict for "{info.field_name}"')
+        # type error here does not get caught by pydantic
+        raise ValueError(f'expect list or dict for "{info.field_name}"')
 
     def iter_requests(self) -> Iterator[Request]:
         seen_names = set()

--- a/secrets_env/console/commands/show.py
+++ b/secrets_env/console/commands/show.py
@@ -51,7 +51,7 @@ def show(config: Path | None):
     # sources
     click.echo(click.style("Sources:", fg="cyan"))
     for i, source in enumerate(cfg.providers.values()):
-        print_model(i, source.name or "(anonymous)", source)
+        print_model(i, source.name, source)
 
     # requests
     click.echo(click.style("Secrets:", fg="cyan"))

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -52,9 +52,13 @@ class TestLoadLocalConfig:
         config = load_local_config(None)
 
         assert len(config.providers) == 1
-        assert config.providers[None] == DebugProvider(value="never gonna give you up")
+        assert config.providers == {
+            "debug": DebugProvider(value="never gonna give you up")
+        }
         assert len(config.requests) == 1
-        assert config.requests[0] == Request(name="TEST_VAR", value="foo")
+        assert config.requests == [
+            Request(name="TEST_VAR", value="foo"),
+        ]
 
     def test_success_3(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         config_path = tmp_path / "config.yaml"

--- a/tests/providers/test_providers.py
+++ b/tests/providers/test_providers.py
@@ -43,12 +43,14 @@ class TestGetProvider:
 class TestDebugProvider:
     def test(self):
         provider = DebugProvider(value="bar")
+        assert provider.name == "debug"
         assert provider(Request(name="test", value="foo")) == "bar"
 
 
 class TestPlainTextProvider:
     def test(self):
         provider = PlainTextProvider()
+        assert provider.name == "plain"
         assert provider(Request(name="test", value="foo")) == "foo"
         assert provider(Request(name="test", value="")) == ""
 


### PR DESCRIPTION
- **type + doc**
- **apply to parser**
- **apply to command**
- **apply to test**
- **doc**
